### PR TITLE
fix: handle duplicates in changeEmailDomain (#6725)

### DIFF
--- a/packages/server/graphql/private/typeDefs/changeEmailDomain.graphql
+++ b/packages/server/graphql/private/typeDefs/changeEmailDomain.graphql
@@ -24,5 +24,10 @@ type ChangeEmailDomainSuccess {
   """
   The users whose domains were changed
   """
-  users: [User!]!
+  usersUpdated: [User!]!
+
+  """
+  Users whose domains were not changed as they were already in the new domain
+  """
+  usersNotUpdated: [User!]!
 }

--- a/packages/server/graphql/private/types/ChangeEmailDomainSuccess.ts
+++ b/packages/server/graphql/private/types/ChangeEmailDomainSuccess.ts
@@ -2,12 +2,17 @@ import isValid from '../../../graphql/isValid'
 import {ChangeEmailDomainSuccessResolvers} from '../../private/resolverTypes'
 
 export type ChangeEmailDomainSuccessSource = {
-  userIds: string[]
+  usersUpdatedIds: string[]
+  usersNotUpdatedIds: string[]
 }
 
 const ChangeEmailDomainSuccess: ChangeEmailDomainSuccessResolvers = {
-  users: async ({userIds}, _args, {dataLoader}) => {
-    const users = (await dataLoader.get('users').loadMany(userIds)).filter(isValid)
+  usersUpdated: async ({usersUpdatedIds}, _args, {dataLoader}) => {
+    const users = (await dataLoader.get('users').loadMany(usersUpdatedIds)).filter(isValid)
+    return users
+  },
+  usersNotUpdated: async ({usersNotUpdatedIds}, _args, {dataLoader}) => {
+    const users = (await dataLoader.get('users').loadMany(usersNotUpdatedIds)).filter(isValid)
     return users
   }
 }

--- a/packages/server/postgres/queries/src/updateUserEmailDomainsQuery.sql
+++ b/packages/server/postgres/queries/src/updateUserEmailDomainsQuery.sql
@@ -1,8 +1,9 @@
 /*
   @name updateUserEmailDomainsQuery
+  @param userIds -> (...)
 */
 
 UPDATE "User" SET email =
 CONCAT(LEFT(email, POSITION('@' in email)), :newDomain::VARCHAR)
-WHERE domain = :oldDomain
+WHERE id in :userIds
 RETURNING id;

--- a/packages/server/postgres/queries/updateUserEmailDomainsToPG.ts
+++ b/packages/server/postgres/queries/updateUserEmailDomainsToPG.ts
@@ -1,7 +1,8 @@
 import getPg from '../getPg'
 import {updateUserEmailDomainsQuery} from './generated/updateUserEmailDomainsQuery'
 
-const updateUserEmailDomainsToPG = async (oldDomain: string, newDomain: string) => {
-  return updateUserEmailDomainsQuery.run({oldDomain, newDomain}, getPg())
+const updateUserEmailDomainsToPG = async (newDomain: string, userIds: string[]) => {
+  if (!userIds.length) return []
+  return updateUserEmailDomainsQuery.run({newDomain, userIds}, getPg())
 }
 export default updateUserEmailDomainsToPG


### PR DESCRIPTION
* feat: editable agenda items

* change updateUserEmailDomainsToPG to accept userIds to prevent duplicate error

* change name from oldDomainUserIds to oldDomainFilteredUserIds

* change name to filteredUserIdsByOldDomain

* return duplicate users from changeEmailDomain

* Revert "return duplicate users from changeEmailDomain"

This reverts commit ab6f7b91d7b74642b5d6cf25153780b63e09d393.

* return usersNotUpdatedIds

* Revert "feat: editable agenda items"

This reverts commit 08902f07924c40fd0ee88bdb1f153b1d5d9fd1e1.

* simplify changeEmailDomain logic and remove generated query

Co-authored-by: Pavel Shapel <p.shapel@gmail.com>

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
